### PR TITLE
Save a symptom and a diagnosis once per encounter

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientdashboardapp/model/Diagnosis.java
+++ b/api/src/main/java/org/openmrs/module/patientdashboardapp/model/Diagnosis.java
@@ -1,15 +1,23 @@
 package org.openmrs.module.patientdashboardapp.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.Concept;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.hospitalcore.PatientQueueService;
 import org.openmrs.module.hospitalcore.util.PatientDashboardConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Diagnosis {
 
 	//TODO: move to global properties
 	private static final String FINAL_DIAGNOSIS_CONCEPT_NAME = "FINAL DIAGNOSIS";
+	
+	private static final Logger logger = LoggerFactory.getLogger(Diagnosis.class);
 
 	public Diagnosis(Concept concept) {
 		this.id = concept.getConceptId();
@@ -37,13 +45,21 @@ public class Diagnosis {
 	private String label;
 
 	public void addObs(Encounter encounter, Obs obsGroup, Boolean isProvisional) {
-		Concept diagnosisConcept;
-		if (!isProvisional) {
-			diagnosisConcept = Context.getConceptService().getConcept(FINAL_DIAGNOSIS_CONCEPT_NAME);
-		} else {
+		List<Diagnosis> previousProvisionalDiagnoses = getPreviousDiagnoses(encounter.getPatient().getPatientId());
+		if (isProvisional && !previousProvisionalDiagnoses.contains(this)) {
 			String provisionalDiagnosisConceptName = Context.getAdministrationService().getGlobalProperty(PatientDashboardConstants.PROPERTY_PROVISIONAL_DIAGNOSIS);
-			diagnosisConcept = Context.getConceptService().getConcept(provisionalDiagnosisConceptName);
+			Concept diagnosisConcept = Context.getConceptService().getConcept(provisionalDiagnosisConceptName);
+			addObsToEncounter(encounter, obsGroup, diagnosisConcept);
 		}
+		
+		if (!isProvisional) {
+			Concept diagnosisConcept = Context.getConceptService().getConcept(FINAL_DIAGNOSIS_CONCEPT_NAME);
+			addObsToEncounter(encounter, obsGroup, diagnosisConcept);
+		}
+	}
+
+	private void addObsToEncounter(Encounter encounter, Obs obsGroup,
+			Concept diagnosisConcept) {
 		Obs obsDiagnosis = new Obs();
 		obsDiagnosis.setConcept(diagnosisConcept);
 		obsDiagnosis.setObsGroup(obsGroup);
@@ -54,4 +70,47 @@ public class Diagnosis {
 		obsDiagnosis.setPerson(encounter.getPatient());
 		encounter.addObs(obsDiagnosis);
 	}
+	
+	public static List<Diagnosis> getPreviousDiagnoses(Integer patientId) {
+		logger.debug("Fetching previous provisional diagnoses");
+		List<Diagnosis> previousDiagnoses = new ArrayList<Diagnosis>();
+		PatientQueueService queueService = Context.getService(PatientQueueService.class);
+		List<Obs> diagnosisObsns = queueService.getAllDiagnosis(patientId);
+		for (Obs diagnosisObs : diagnosisObsns) {
+			previousDiagnoses.add(new Diagnosis(diagnosisObs.getValueCoded()));
+		}
+		
+		logger.debug("Found " + previousDiagnoses.size() + " previous provisional diagnoses");
+		return previousDiagnoses;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 1;
+		hash = hash * 31;
+		hash = hash * 31 + (this.id == null ? 0 : this.id.hashCode());
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof Diagnosis)) {
+			return false;
+		}
+		Diagnosis otherDiagnosis = (Diagnosis) obj;
+		return (this.id.equals(otherDiagnosis.id))
+				&& ((this.id == null)
+						? otherDiagnosis.id == null
+						: this.id.equals(otherDiagnosis.id));
+	}
+
+	@Override
+	public String toString() {
+		return "{id=" + this.id + ", label=" + this.label + "}";
+	}
+
 }

--- a/api/src/main/java/org/openmrs/module/patientdashboardapp/model/Note.java
+++ b/api/src/main/java/org/openmrs/module/patientdashboardapp/model/Note.java
@@ -37,8 +37,12 @@ public class Note {
 		this.opdId = opdId;
 		this.admitted = Context.getService(IpdService.class).getAdmittedByPatientId(patientId) != null;
 		this.opdLogId = opdLogId;
-		loadDiagnoses(patientId);
-		loadSigns(patientId);
+		this.diagnoses = Diagnosis.getPreviousDiagnoses(patientId);
+		this.signs = Sign.getPreviousSigns(patientId);		
+
+		if (diagnoses.size() > 0) {
+			this.diagnosisProvisional = true;
+		}
 	}
 
 	private int patientId;
@@ -185,25 +189,6 @@ public class Note {
 		this.physicalExamination = physicalExamination;
 	}
 
-	private void loadSigns(Integer patientId) {
-		PatientQueueService queueService = Context.getService(PatientQueueService.class);
-		List<Obs> symptomObs = queueService.getAllSymptom(patientId);
-		for (Obs signObs : symptomObs) {
-			signs.add(new Sign(signObs.getValueCoded()));
-		}
-	}
-
-	private void loadDiagnoses(Integer patientId) {
-		PatientQueueService queueService = Context.getService(PatientQueueService.class);
-		List<Obs> diagnosisObsns = queueService.getAllDiagnosis(patientId);
-		for (Obs diagnosisObs : diagnosisObsns) {
-			diagnoses.add(new Diagnosis(diagnosisObs.getValueCoded()));
-		}
-		if (diagnoses.size() > 0) {
-			this.diagnosisProvisional = true;
-		}
-	}
-
 	public Encounter save() {
 		Patient patient = Context.getPatientService().getPatient(this.patientId);
 		Obs obsGroup = Context.getService(HospitalCoreService.class).getObsGroupCurrentDate(patient.getPersonId());
@@ -254,16 +239,15 @@ public class Note {
 		for (Sign sign : this.signs) {
 			sign.addObs(encounter, obsGroup);
 		}
-		for (Procedure procedure : this.procedures)
-		{
+		for (Procedure procedure : this.procedures) {
 			procedure.addObs(encounter,obsGroup);
 		}
-		for(Investigation investigation : this.investigations)
-		{
+		
+		for(Investigation investigation : this.investigations) {
 			investigation.addObs(encounter,obsGroup);
 		}
-		for (Diagnosis diagnosis : this.diagnoses)
-		{
+		
+		for (Diagnosis diagnosis : this.diagnoses) {
 			diagnosis.addObs(encounter, obsGroup, this.diagnosisProvisional);
 		}
 		

--- a/api/src/main/java/org/openmrs/module/patientdashboardapp/model/Sign.java
+++ b/api/src/main/java/org/openmrs/module/patientdashboardapp/model/Sign.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.patientdashboardapp.model;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -8,6 +9,7 @@ import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.hospitalcore.PatientDashboardService;
+import org.openmrs.module.hospitalcore.PatientQueueService;
 import org.openmrs.module.hospitalcore.model.Symptom;
 import org.openmrs.module.hospitalcore.util.PatientDashboardConstants;
 
@@ -26,6 +28,7 @@ public class Sign {
 	private String label;
 	private Concept symptomConcept;
 	private List<Qualifier> qualifiers;
+	private List<Sign> previousSigns;
 
 	public Integer getId() {
 		return id;
@@ -55,35 +58,98 @@ public class Sign {
 		return this.symptomConcept == null ?
 				Context.getConceptService().getConcept(this.id) : this.symptomConcept;
 	}
+	
+	public static List<Sign> getPreviousSigns(Integer patientId) {
+		List<Sign> previousSigns = new ArrayList<Sign>();
+		PatientQueueService queueService = Context.getService(PatientQueueService.class);
+		List<Obs> symptomObs = queueService.getAllSymptom(patientId);
+		for (Obs signObs : symptomObs) {
+			previousSigns.add(new Sign(signObs.getValueCoded()));
+		}
+		return previousSigns;
+	}
 
 	public void addObs(Encounter encounter, Obs obsGroup) {
-		String symptomConceptName = Context.getAdministrationService()
-				.getGlobalProperty(PatientDashboardConstants.PROPERTY_SYMPTOM);
-		Obs obsSymptom = new Obs();
-		obsSymptom.setConcept(Context.getConceptService().getConcept(symptomConceptName));
-		obsSymptom.setValueCoded(getSymtomConcept());
-		obsSymptom.setObsGroup(obsGroup);
-		obsSymptom.setCreator(encounter.getCreator());
-		obsSymptom.setDateCreated(encounter.getDateCreated());
-		obsSymptom.setEncounter(encounter);
-		obsSymptom.setPerson(encounter.getPatient());
-		encounter.addObs(obsSymptom);
+		if (previousSigns == null) {
+			previousSigns = getPreviousSigns(encounter.getPatient().getPatientId());
+		}
+		if (!previousSigns.contains(this)) {
+			String symptomConceptName = Context.getAdministrationService()
+					.getGlobalProperty(PatientDashboardConstants.PROPERTY_SYMPTOM);
+			Obs obsSymptom = new Obs();
+			obsSymptom.setConcept(Context.getConceptService().getConcept(symptomConceptName));
+			obsSymptom.setValueCoded(getSymtomConcept());
+			obsSymptom.setObsGroup(obsGroup);
+			obsSymptom.setCreator(encounter.getCreator());
+			obsSymptom.setDateCreated(encounter.getDateCreated());
+			obsSymptom.setEncounter(encounter);
+			obsSymptom.setPerson(encounter.getPatient());
+			encounter.addObs(obsSymptom);
+		}
 	}
 
 	public void save(Encounter encounter) {
-
-		Symptom symptom = new Symptom();
-		symptom.setEncounter(encounter);
-		symptom.setSymptomConcept(getSymtomConcept());
-		symptom.setCreatedDate(new Date());
-		symptom.setCreator(Context.getAuthenticatedUser());
-
-		PatientDashboardService patientDashboardService = Context.getService(PatientDashboardService.class);
-		Symptom sym = patientDashboardService.saveSymptom(symptom);
-
-		for (Qualifier qualifier : this.qualifiers) {
-			qualifier.save(sym);
+		if (previousSigns != null) {
+			previousSigns = getPreviousSigns(encounter.getPatient().getPatientId());
 		}
+		Symptom savedSymptom = null;
+		if (!previousSigns.contains(this)) {
+
+			Symptom symptom = new Symptom();
+			symptom.setEncounter(encounter);
+			symptom.setSymptomConcept(getSymtomConcept());
+			symptom.setCreatedDate(new Date());
+			symptom.setCreator(Context.getAuthenticatedUser());
+	
+			PatientDashboardService patientDashboardService = Context.getService(PatientDashboardService.class);
+			savedSymptom = patientDashboardService.saveSymptom(symptom);
+		} else {
+			List<Obs> symptomObs = Context.getService(PatientQueueService.class).getAllSymptom(encounter.getPatient().getPatientId());
+			if (symptomObs.size() > 0) {
+				List<Symptom> symptoms = Context.getService(PatientDashboardService.class).getSymptom(symptomObs.get(0).getEncounter());
+				for (Symptom symptom : symptoms) {
+					if (symptom.getSymptomConcept().equals(this.getSymtomConcept())) {
+						savedSymptom = symptom;
+						break;
+					}
+				}
+			}
+		}
+
+		if (this.qualifiers != null && savedSymptom != null) {
+			for (Qualifier qualifier : this.qualifiers) {
+				qualifier.save(savedSymptom);
+			}
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 1;
+		hash = hash * 31;
+		hash = hash * 31 + (this.id == null ? 0 : this.id.hashCode());
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof Sign)) {
+			return false;
+		}
+		Sign otherSign = (Sign) obj;
+		return (this.id.equals(otherSign.id))
+				&& ((this.id == null)
+						? otherSign.id == null
+						: this.id.equals(otherSign.id));
+	}
+
+	@Override
+	public String toString() {
+		return "{id=" + this.id + ", label=" + this.label + "}";
 	}
 
 }

--- a/api/src/test/java/org/openmrs/module/patientdashboardapp/model/DiagnosisModelTest.java
+++ b/api/src/test/java/org/openmrs/module/patientdashboardapp/model/DiagnosisModelTest.java
@@ -1,0 +1,49 @@
+package org.openmrs.module.patientdashboardapp.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.Encounter;
+import org.openmrs.api.context.Context;
+
+public class DiagnosisModelTest extends AbstractModelTest {
+
+	@Test 
+	public void save_shouldSaveAGivenProvisionalDiagnosisOnlyOnceForASingleEncounter() throws Exception {
+		executeDataSet("notes-concepts.xml");
+		Encounter encounter = createEncounter();
+		Diagnosis malaria = new Diagnosis(Context.getConceptService().getConcept(10003));
+		malaria.addObs(encounter, null, true);
+		Context.getEncounterService().saveEncounter(encounter);
+		
+		Assert.assertEquals(1, encounter.getObs().size());
+		
+		//allow time to elaspse for diagnosis to be considered a previous diagnosis
+		Thread.sleep(1000);
+		
+		Encounter anotherEncounter = createEncounter();
+		malaria.addObs(anotherEncounter, null, true);
+		
+		Diagnosis.getPreviousDiagnoses(anotherEncounter.getPatient().getPatientId());
+		
+		Assert.assertEquals(0, anotherEncounter.getObs().size());
+	}
+
+	@Test public void addObs_shouldAddFinalDiagnosisToEncounterObs() throws Exception {
+		executeDataSet("notes-concepts.xml");
+		Encounter encounter = createEncounter();
+		Diagnosis malaria = new Diagnosis(Context.getConceptService().getConcept(10003));
+		malaria.addObs(encounter, null, true);
+		Context.getEncounterService().saveEncounter(encounter);
+
+		Assert.assertEquals(1, encounter.getObs().size());
+
+		//allow time to elaspse for diagnosis to be considered a previous diagnosis
+		Thread.sleep(1000);
+
+		Encounter anotherEncounter = createEncounter();
+		malaria.addObs(anotherEncounter, null, false);
+
+		Assert.assertEquals(1, anotherEncounter.getObs().size());
+	}
+
+}

--- a/api/src/test/java/org/openmrs/module/patientdashboardapp/model/QualifierModelTest.java
+++ b/api/src/test/java/org/openmrs/module/patientdashboardapp/model/QualifierModelTest.java
@@ -26,6 +26,54 @@ public class QualifierModelTest extends AbstractModelTest {
 		
 		Assert.assertEquals(qualifier.getAnswer().getId(), pds.getAnswer(pds.getQuestion(symptom).get(0)).getAnswerConcept().getConceptId());
 	}
+	
+	@Test public void save_shouldUpdateSymptomQualifierIfItHasChanged() throws Exception {
+		executeDataSet("notes-concepts.xml");
+		PatientDashboardService pds = Context.getService(PatientDashboardService.class);
+		Symptom headache = createSymptom();
+		headache = pds.saveSymptom(headache);
+		
+		Qualifier severity = new Qualifier(Context.getConceptService().getConcept(10004));
+		Option aFive = new Option(Context.getConceptService().getConcept(10006));
+		severity.setAnswer(aFive);
+		severity.save(headache);
+		
+		//confirm qualifier has been saved
+		Assert.assertEquals(aFive.getId(), pds.getAnswer(pds.getQuestion(headache).get(0)).getAnswerConcept().getConceptId());
+		
+		Option aTen = new Option(Context.getConceptService().getConcept(10007));
+		severity.setAnswer(aTen);
+		severity.save(headache);
+		
+		
+		Assert.assertEquals(aTen.getId(), pds.getAnswer(pds.getQuestion(headache).get(0)).getAnswerConcept().getConceptId());
+		Assert.assertEquals(1, pds.getQuestion(headache).size());
+		
+	}
+	
+	@Test public void save_shouldAddQualifiersToSymptom() throws Exception {
+		executeDataSet("notes-concepts.xml");
+		PatientDashboardService pds = Context.getService(PatientDashboardService.class);
+		Symptom headache = createSymptom();
+		headache = pds.saveSymptom(headache);
+		
+		Qualifier severity = new Qualifier(Context.getConceptService().getConcept(10004));
+		Option aFive = new Option(Context.getConceptService().getConcept(10006));
+		severity.setAnswer(aFive);
+		severity.save(headache);
+		
+		//confirm qualifier has been saved
+		Assert.assertEquals(aFive.getId(), pds.getAnswer(pds.getQuestion(headache).get(0)).getAnswerConcept().getConceptId());
+		
+		Qualifier comment = new Qualifier(Context.getConceptService().getConcept(10008));
+		String aComment = "Some comment...";
+		comment.setFreeText(aComment);
+		comment.save(headache);
+		
+		
+		Assert.assertEquals(aComment, pds.getAnswer(pds.getQuestion(headache).get(1)).getFreeText());
+		Assert.assertEquals(2, pds.getQuestion(headache).size());
+	}
 
 	private Symptom createSymptom() {
 		Symptom symptom = new Symptom();

--- a/api/src/test/java/org/openmrs/module/patientdashboardapp/model/SignModelTest.java
+++ b/api/src/test/java/org/openmrs/module/patientdashboardapp/model/SignModelTest.java
@@ -1,0 +1,31 @@
+package org.openmrs.module.patientdashboardapp.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.Encounter;
+import org.openmrs.api.context.Context;
+
+public class SignModelTest extends AbstractModelTest {
+
+	@Test
+	public void addObs_shouldSaveAGivenSymptomOnlyOnceForASingleEncounter() throws Exception {
+		executeDataSet("notes-concepts.xml");
+		Encounter encounter = createEncounter();
+		Sign headache = new Sign(Context.getConceptService().getConcept(9900));
+		headache.addObs(encounter, null);
+		Context.getEncounterService().saveEncounter(encounter);
+		headache.save(encounter);
+		
+		Assert.assertEquals(1, encounter.getObs().size());
+		
+		//allow time to elaspse for diagnosis to be considered a previous diagnosis
+		Thread.sleep(1000);
+		
+		Encounter anotherEncounter = createEncounter();
+		headache = new Sign(Context.getConceptService().getConcept(9900));
+		headache.addObs(anotherEncounter, null);
+		
+		Assert.assertEquals(0, anotherEncounter.getObs().size());
+	}
+
+}

--- a/api/src/test/resources/notes-concepts.xml
+++ b/api/src/test/resources/notes-concepts.xml
@@ -21,8 +21,19 @@
   <concept concept_id="9986" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="dc82860a-e946-43d1-9b1f-488755fa7bf3"/>
   <concept concept_id="9987" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="49d94fe2-c017-11e5-9912-ba0be0483c18"/>
   <concept concept_id="9988" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="49d95352-c017-11e5-9912-ba0be0483c18"/>
+  <concept concept_id="9989" retired="false" datatype_id="2" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="3c0e2a4b-da0f-11e5-a3f2-34e6d77c15d6"/>
   <concept concept_id="9960" retired="false" datatype_id="2" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="6be53e7f-c045-11e5-9a67-34e6d77c15d6"/>
   <concept concept_id="9961" retired="false" datatype_id="2" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="8da1a020-c045-11e5-9a67-34e6d77c15d6"/>
+  <concept concept_id="9900" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="fcb5480c-da0f-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10001" retired="false" datatype_id="2" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="9f59b101-dade-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10002" retired="false" datatype_id="2" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="9556452d-dade-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10003" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="abf9d3e8-dae1-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10003" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="abf9d3e8-dae1-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10004" retired="false" datatype_id="2" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="657b12b0-dbb4-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10005" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="7b750c4f-dbb4-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10006" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="8441794d-dbb4-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10007" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="8c285a01-dbb4-11e5-a3f2-34e6d77c15d6"/>
+  <concept concept_id="10008" retired="false" datatype_id="3" class_id="11" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" version="" uuid="aef9752b-dbb9-11e5-a3f2-34e6d77c15d6"/>
 
   <concept_class concept_class_id="20" name="Frequency" description="Drug frequency" creator="1" date_created="2008-08-15 13:56:55.0" retired="false" uuid="0fd33d76-8b4b-445f-899e-161c5e85d36c"/>
 
@@ -41,6 +52,16 @@
   <concept_name concept_id="9986" name="General OPD" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4012" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="cae934c5-7d60-41bc-88bd-1ac64c7beb47"/>
   <concept_name concept_id="9987" name="External" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4013" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="75347aad-b798-4977-ae44-09fdc959c606"/>  
   <concept_name concept_id="9988" name="Internal" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4014" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="f5a034a8-9516-4fd4-93cb-fb37dcfd6f8c"/>
+  <concept_name concept_id="9989" name="Symptom" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4015" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="14a4b008-da0f-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="9900" name="Headache" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4016" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="30d09cc6-da10-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10001" name="Provisional Diagnosis" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4017" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="536ea3f2-dade-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10002" name="Final Diagnosis" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4018" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="27ee653b-dade-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10003" name="Malaria" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4019" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="f34f4dbb-dae0-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10004" name="How severe is the headache?" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4020" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="485c4480-dba9-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10005" name="A one" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4021" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="2d0696f6-dbaa-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10006" name="A five" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4022" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="3fb4a20c-dbaa-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10007" name="A ten" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4023" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="48d22a14-dbaa-11e5-a3f2-34e6d77c15d6"/>
+  <concept_name concept_id="10008" name="Comment" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="4024" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="adfd3485-dbb4-11e5-a3f2-34e6d77c15d6"/>
 
   <patient_identifier_type patient_identifier_type_id="1009" name="Test Identifier Type" description="Test description" check_digit="false" creator="1" date_created="2005-01-01 00:00:00.0" required="false" retired="false"  uuid="66e16926-a235-11e5-bf7f-feff819cdc9f"/>
   <person person_id="3009" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" gender="F"  uuid="b29e64f4-a235-11e5-bf7f-feff819cdc9f"/>
@@ -56,6 +77,8 @@
   <global_property property="patientdashboard.internalReferralConcept" property_value="9988" uuid="df455a2b-7131-4298-bb7e-809033ccd700"/>
   <global_property property="patientdashboard.OPDRootConcept" property_value="9960" uuid="33c06098-c044-11e5-9a67-34e6d77c15d6"/>
   <global_property property="patientdashboard.externalHospitalConcept" property_value="9961" uuid="fe6275c0-c043-11e5-9a67-34e6d77c15d6"/>
+  <global_property property="patientdashboard.symptomConcept" property_value="symptom" uuid="f1987d67-da0e-11e5-a3f2-34e6d77c15d6"/>
+  <global_property property="patientdashboard.provisionalDiagnosisConcept" property_value="Provisional Diagnosis" uuid="882627cf-dae1-11e5-a3f2-34e6d77c15d6"/>
 
   <billing_billable_service service_id="1" concept_id="9993" name="Allergy Shots" short_name="" price="50" disable="false" category="9995" />
   <billing_billable_service service_id="2" concept_id="9994" name="LAPAROTOMY" short_name="" price="500" disable="false" category="9996" />


### PR DESCRIPTION
This also saves a symptom's qualifier only once and updates it if
necessary.